### PR TITLE
Remove all Copyright Notices from hadez16

### DIFF
--- a/AutoScanCompare/CodingCompare.Designer.cs
+++ b/AutoScanCompare/CodingCompare.Designer.cs
@@ -364,7 +364,7 @@
 			this.label14.Name = "label14";
 			this.label14.Size = new System.Drawing.Size(62, 13);
 			this.label14.TabIndex = 29;
-			this.label14.Text = "by hadez16";
+			this.label14.Text = "by VCDS.de";
 			// 
 			// richTextBox1
 			// 

--- a/AutoScanCompare/Form1.cs
+++ b/AutoScanCompare/Form1.cs
@@ -36,7 +36,7 @@ namespace AutoScanCompare
 			labelMJ1.Text = WinFormStrings.str_modelYear;
 			labelMJ2.Text = WinFormStrings.str_modelYear;
 
-			label14.Text = "V" + Assembly.GetExecutingAssembly().GetName().Version.ToString() + " by hadez16";
+			label14.Text = "V" + Assembly.GetExecutingAssembly().GetName().Version.ToString() + " by VCDS.de";
 			
 			this.Text = WinFormStrings.str_winformTitle;
 			label1.Text = WinFormStrings.str_autoscan1;

--- a/AutoScanCompare/Form1.resx
+++ b/AutoScanCompare/Form1.resx
@@ -352,7 +352,7 @@
     <value>30</value>
   </data>
   <data name="label14.Text" xml:space="preserve">
-    <value>V2.0    by hadez16</value>
+    <value>V2.0    by VCDS.de</value>
   </data>
   <data name="&gt;&gt;label14.Name" xml:space="preserve">
     <value>label14</value>
@@ -1301,7 +1301,7 @@
     <value>730, 742</value>
   </data>
   <data name="$this.Text" xml:space="preserve">
-    <value>VCDS Autoscan-Vergleichstaschenmesser (by hadez16)</value>
+    <value>VCDS Autoscan-Vergleichstaschenmesser (by VCDS.de)</value>
   </data>
   <data name="&gt;&gt;$this.Name" xml:space="preserve">
     <value>Form1</value>

--- a/AutoScanCompare/Form2.Designer.cs
+++ b/AutoScanCompare/Form2.Designer.cs
@@ -70,7 +70,7 @@
 			this.label14.Name = "label14";
 			this.label14.Size = new System.Drawing.Size(96, 13);
 			this.label14.TabIndex = 31;
-			this.label14.Text = "V2.0    by hadez16";
+			this.label14.Text = "V2.0    by VCDS.de";
 			// 
 			// tabControl1
 			// 

--- a/AutoScanCompare/Form2.cs
+++ b/AutoScanCompare/Form2.cs
@@ -41,7 +41,7 @@ namespace AutoScanCompare
 			tabControl1.ShowToolTips = true;
 			this.DragEnter += new System.Windows.Forms.DragEventHandler(this.doDragEnter);
 			this.DragDrop += new System.Windows.Forms.DragEventHandler(this.doDragDrop);
-			label14.Text = "V" + Assembly.GetExecutingAssembly().GetName().Version.ToString() + " by hadez16";
+			label14.Text = "V" + Assembly.GetExecutingAssembly().GetName().Version.ToString() + " by VCDS.de";
 
 			labelSearchCoding.Text = WinFormStrings.str_searchCodingTitle;
 			labelSearchCodingUnit.Text = WinFormStrings.str_searchCodingAdresse;

--- a/AutoScanCompare/Properties/AssemblyInfo.cs
+++ b/AutoScanCompare/Properties/AssemblyInfo.cs
@@ -8,9 +8,9 @@ using System.Runtime.InteropServices;
 [assembly: AssemblyTitle("VCDS CodingCompare")]
 [assembly: AssemblyDescription("")]
 [assembly: AssemblyConfiguration("")]
-[assembly: AssemblyCompany("hadez16")]
+[assembly: AssemblyCompany("VCDS.de")]
 [assembly: AssemblyProduct("VCDS CodingCompare")]
-[assembly: AssemblyCopyright("hadez16")]
+[assembly: AssemblyCopyright("VCDS.de")]
 [assembly: AssemblyTrademark("")]
 [assembly: AssemblyCulture("")]
 

--- a/AutoScanCompare/Resources/WinFormStrings.Designer.cs
+++ b/AutoScanCompare/Resources/WinFormStrings.Designer.cs
@@ -502,7 +502,7 @@ namespace CodingCompare.Resources {
         }
         
         /// <summary>
-        ///   Sucht eine lokalisierte Zeichenfolge, die VCDS Autoscan coding compare (by hadez16) ähnelt.
+        ///   Sucht eine lokalisierte Zeichenfolge, die VCDS Autoscan coding compare (by VCDS.de) ähnelt.
         /// </summary>
         internal static string str_winformTitle {
             get {

--- a/AutoScanCompare/Resources/WinFormStrings.de-DE.resx
+++ b/AutoScanCompare/Resources/WinFormStrings.de-DE.resx
@@ -163,7 +163,7 @@
     <value>synchrones Scrollen</value>
   </data>
   <data name="str_winformTitle" xml:space="preserve">
-    <value>VCDS Autoscan Codierungsvergleich (by hadez16)</value>
+    <value>VCDS Autoscan Codierungsvergleich (by VCDS.de)</value>
   </data>
   <data name="str_Adresse" xml:space="preserve">
     <value>Adresse</value>

--- a/AutoScanCompare/Resources/WinFormStrings.resx
+++ b/AutoScanCompare/Resources/WinFormStrings.resx
@@ -163,7 +163,7 @@
     <value>synchronous scrolling</value>
   </data>
   <data name="str_winformTitle" xml:space="preserve">
-    <value>VCDS Autoscan coding compare (by hadez16)</value>
+    <value>VCDS Autoscan coding compare (by VCDS.de)</value>
   </data>
   <data name="str_Adresse" xml:space="preserve">
     <value>Address</value>


### PR DESCRIPTION
In order to make the product one of the VCDS.de trademark, all notices of hadez16 were removed by using
`grep -r "hadez" . > filenames.txt`
then for all filenames
`vim <filename> -c :%s/hadez16/VCDS.de/g -c wq`.
The `filenames.txt` was removed